### PR TITLE
reverse change of combining blocks purger and tenant deletion

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -279,21 +279,22 @@ func (a *API) RegisterChunksPurger(store *purger.DeleteStore, deleteRequestCance
 	a.RegisterRoute(path.Join(a.cfg.LegacyHTTPPrefix, "/api/v1/admin/tsdb/cancel_delete_request"), http.HandlerFunc(deleteRequestHandler.CancelDeleteRequestHandler), true, "PUT", "POST")
 }
 
-func (a *API) RegisterBlocksPurger(blocksPurger *purger.BlocksPurgerAPI, seriesDeletionEnabled bool) {
+func (a *API) RegisterTenantDeletion(api *purger.TenantDeletionAPI) {
+	a.RegisterRoute("/purger/delete_tenant", http.HandlerFunc(api.DeleteTenant), true, "POST")
+	a.RegisterRoute("/purger/delete_tenant_status", http.HandlerFunc(api.DeleteTenantStatus), true, "GET")
+}
 
-	if seriesDeletionEnabled {
-		a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/admin/tsdb/delete_series"), http.HandlerFunc(blocksPurger.AddDeleteRequestHandler), true, "PUT", "POST")
-		a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/admin/tsdb/delete_series"), http.HandlerFunc(blocksPurger.GetAllDeleteRequestsHandler), true, "GET")
-		a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/admin/tsdb/cancel_delete_request"), http.HandlerFunc(blocksPurger.CancelDeleteRequestHandler), true, "PUT", "POST")
+func (a *API) RegisterBlocksPurger(blocksPurger *purger.BlocksPurgerAPI) {
 
-		// Legacy Routes
-		a.RegisterRoute(path.Join(a.cfg.LegacyHTTPPrefix, "/api/v1/admin/tsdb/delete_series"), http.HandlerFunc(blocksPurger.AddDeleteRequestHandler), true, "PUT", "POST")
-		a.RegisterRoute(path.Join(a.cfg.LegacyHTTPPrefix, "/api/v1/admin/tsdb/delete_series"), http.HandlerFunc(blocksPurger.AddDeleteRequestHandler), true, "GET")
-		a.RegisterRoute(path.Join(a.cfg.LegacyHTTPPrefix, "/api/v1/admin/tsdb/cancel_delete_request"), http.HandlerFunc(blocksPurger.CancelDeleteRequestHandler), true, "PUT", "POST")
-	}
-	// Tenant Deletion
-	a.RegisterRoute("/purger/delete_tenant", http.HandlerFunc(blocksPurger.DeleteTenant), true, "POST")
-	a.RegisterRoute("/purger/delete_tenant_status", http.HandlerFunc(blocksPurger.DeleteTenantStatus), true, "GET")
+	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/admin/tsdb/delete_series"), http.HandlerFunc(blocksPurger.AddDeleteRequestHandler), true, "PUT", "POST")
+	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/admin/tsdb/delete_series"), http.HandlerFunc(blocksPurger.GetAllDeleteRequestsHandler), true, "GET")
+	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/admin/tsdb/cancel_delete_request"), http.HandlerFunc(blocksPurger.CancelDeleteRequestHandler), true, "PUT", "POST")
+
+	// Legacy Routes
+	a.RegisterRoute(path.Join(a.cfg.LegacyHTTPPrefix, "/api/v1/admin/tsdb/delete_series"), http.HandlerFunc(blocksPurger.AddDeleteRequestHandler), true, "PUT", "POST")
+	a.RegisterRoute(path.Join(a.cfg.LegacyHTTPPrefix, "/api/v1/admin/tsdb/delete_series"), http.HandlerFunc(blocksPurger.AddDeleteRequestHandler), true, "GET")
+	a.RegisterRoute(path.Join(a.cfg.LegacyHTTPPrefix, "/api/v1/admin/tsdb/cancel_delete_request"), http.HandlerFunc(blocksPurger.CancelDeleteRequestHandler), true, "PUT", "POST")
+
 }
 
 // RegisterRuler registers routes associated with the Ruler service.

--- a/pkg/chunk/purger/tenant_deletion_api.go
+++ b/pkg/chunk/purger/tenant_deletion_api.go
@@ -1,0 +1,128 @@
+package purger
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/thanos-io/thanos/pkg/objstore"
+
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
+	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/tenant"
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+type TenantDeletionAPI struct {
+	bucketClient objstore.Bucket
+	logger       log.Logger
+	cfgProvider  bucket.TenantConfigProvider
+}
+
+func NewTenantDeletionAPI(storageCfg cortex_tsdb.BlocksStorageConfig, cfgProvider bucket.TenantConfigProvider, logger log.Logger, reg prometheus.Registerer) (*TenantDeletionAPI, error) {
+	bucketClient, err := createBucketClient(storageCfg, logger, "tenant-deletion-purger", reg)
+	if err != nil {
+		return nil, err
+	}
+
+	return newTenantDeletionAPI(bucketClient, cfgProvider, logger), nil
+}
+
+func newTenantDeletionAPI(bkt objstore.Bucket, cfgProvider bucket.TenantConfigProvider, logger log.Logger) *TenantDeletionAPI {
+	return &TenantDeletionAPI{
+		bucketClient: bkt,
+		cfgProvider:  cfgProvider,
+		logger:       logger,
+	}
+}
+
+func (api *TenantDeletionAPI) DeleteTenant(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	userID, err := tenant.TenantID(ctx)
+	if err != nil {
+		// When Cortex is running, it uses Auth Middleware for checking X-Scope-OrgID and injecting tenant into context.
+		// Auth Middleware sends http.StatusUnauthorized if X-Scope-OrgID is missing, so we do too here, for consistency.
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	err = cortex_tsdb.WriteTenantDeletionMark(r.Context(), api.bucketClient, userID, api.cfgProvider, cortex_tsdb.NewTenantDeletionMark(time.Now()))
+	if err != nil {
+		level.Error(api.logger).Log("msg", "failed to write tenant deletion mark", "user", userID, "err", err)
+
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	level.Info(api.logger).Log("msg", "tenant deletion mark in blocks storage created", "user", userID)
+
+	w.WriteHeader(http.StatusOK)
+}
+
+type DeleteTenantStatusResponse struct {
+	TenantID      string `json:"tenant_id"`
+	BlocksDeleted bool   `json:"blocks_deleted"`
+}
+
+func (api *TenantDeletionAPI) DeleteTenantStatus(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	userID, err := tenant.TenantID(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	result := DeleteTenantStatusResponse{}
+	result.TenantID = userID
+	result.BlocksDeleted, err = api.isBlocksForUserDeleted(ctx, userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	util.WriteJSONResponse(w, result)
+}
+
+func (api *TenantDeletionAPI) isBlocksForUserDeleted(ctx context.Context, userID string) (bool, error) {
+	var errBlockFound = errors.New("block found")
+
+	userBucket := bucket.NewUserBucketClient(userID, api.bucketClient, api.cfgProvider)
+	err := userBucket.Iter(ctx, "", func(s string) error {
+		s = strings.TrimSuffix(s, "/")
+
+		_, err := ulid.Parse(s)
+		if err != nil {
+			// not block, keep looking
+			return nil
+		}
+
+		// Used as shortcut to stop iteration.
+		return errBlockFound
+	})
+
+	if errors.Is(err, errBlockFound) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	// No blocks found, all good.
+	return true, nil
+}
+
+func createBucketClient(cfg cortex_tsdb.BlocksStorageConfig, logger log.Logger, name string, reg prometheus.Registerer) (objstore.Bucket, error) {
+	bucketClient, err := bucket.NewClient(context.Background(), cfg.Bucket, name, logger, reg)
+	if err != nil {
+		return nil, errors.Wrap(err, "create bucket client")
+	}
+
+	return bucketClient, nil
+}

--- a/pkg/chunk/purger/tenant_deletion_api_test.go
+++ b/pkg/chunk/purger/tenant_deletion_api_test.go
@@ -1,0 +1,90 @@
+package purger
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/weaveworks/common/user"
+
+	"github.com/cortexproject/cortex/pkg/storage/tsdb"
+)
+
+func TestDeleteTenant(t *testing.T) {
+	bkt := objstore.NewInMemBucket()
+	api := newTenantDeletionAPI(bkt, nil, log.NewNopLogger())
+
+	{
+		resp := httptest.NewRecorder()
+		api.DeleteTenant(resp, &http.Request{})
+		require.Equal(t, http.StatusUnauthorized, resp.Code)
+	}
+
+	{
+		ctx := context.Background()
+		ctx = user.InjectOrgID(ctx, "fake")
+
+		req := &http.Request{}
+		resp := httptest.NewRecorder()
+		api.DeleteTenant(resp, req.WithContext(ctx))
+
+		require.Equal(t, http.StatusOK, resp.Code)
+		objs := bkt.Objects()
+		require.NotNil(t, objs[path.Join("fake", tsdb.TenantDeletionMarkPath)])
+	}
+}
+
+func TestDeleteTenantStatus(t *testing.T) {
+	const username = "user"
+
+	for name, tc := range map[string]struct {
+		objects               map[string][]byte
+		expectedBlocksDeleted bool
+	}{
+		"empty": {
+			objects:               nil,
+			expectedBlocksDeleted: true,
+		},
+
+		"no user objects": {
+			objects: map[string][]byte{
+				"different-user/01EQK4QKFHVSZYVJ908Y7HH9E0/meta.json": []byte("data"),
+			},
+			expectedBlocksDeleted: true,
+		},
+
+		"non-block files": {
+			objects: map[string][]byte{
+				"user/deletion-mark.json": []byte("data"),
+			},
+			expectedBlocksDeleted: true,
+		},
+
+		"block files": {
+			objects: map[string][]byte{
+				"user/01EQK4QKFHVSZYVJ908Y7HH9E0/meta.json": []byte("data"),
+			},
+			expectedBlocksDeleted: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			bkt := objstore.NewInMemBucket()
+			// "upload" objects
+			for objName, data := range tc.objects {
+				require.NoError(t, bkt.Upload(context.Background(), objName, bytes.NewReader(data)))
+			}
+
+			api := newTenantDeletionAPI(bkt, nil, log.NewNopLogger())
+
+			res, err := api.isBlocksForUserDeleted(context.Background(), username)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedBlocksDeleted, res)
+		})
+	}
+}


### PR DESCRIPTION

Undo's the changes of combining the tenant deletion API file with the block purger API file.

This can be set aside for a future PR when all the API relating to block storage are moved out of the `chunks` subdirectory. 

Signed-off-by: ilangofman <igofman99@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
